### PR TITLE
Remove unused import from uploadMockData.tsx

### DIFF
--- a/src/utils/uploadMockData.tsx
+++ b/src/utils/uploadMockData.tsx
@@ -7,7 +7,7 @@ import {
   communityStories,
   impactStats,
 } from "../data/mockData";
-import { collection, setDoc, doc } from "firebase/firestore";
+import { setDoc, doc } from "firebase/firestore";
 
 // Converts Date objects to Firestore Timestamps or ISO strings, if needed
 function serialize(obj: any): any {


### PR DESCRIPTION
The 'collection' import from 'firebase/firestore' was removed as it is not used in the file.