### PR TITLE
Remove unused loading state from impactStats hook

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -18,8 +18,7 @@ export default function Home() {
     useCollection("foodCategories");
   const { documents: users = [], loading: usersLoading } =
     useCollection("users");
-  const { documents: impactDocs = [], loading: impactLoading } =
-    useCollection("impactStats");
+  const { documents: impactDocs = [] } = useCollection("impactStats");
   const { documents: communityStories = [], loading: storiesLoading } =
     useCollection("communityStories");
 


### PR DESCRIPTION
The loading state from the useCollection hook for impactStats was removed as it was not being used in the Home page component.